### PR TITLE
Bug fix involving URLs ending in index.html

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ jobs:
         fetch-depth: 0 
     - name: Generate the sitemap
       id: sitemap
-      uses: cicirello/generate-sitemap@v1.6.0
+      uses: cicirello/generate-sitemap@v1.6.1
       with:
         base-url-path: https://THE.URL.TO.YOUR.PAGE/
     - name: Output stats
@@ -157,7 +157,7 @@ jobs:
         fetch-depth: 0 
     - name: Generate the sitemap
       id: sitemap
-      uses: cicirello/generate-sitemap@v1.6.0
+      uses: cicirello/generate-sitemap@v1.6.1
       with:
         base-url-path: https://THE.URL.TO.YOUR.PAGE/
         path-to-root: docs
@@ -198,7 +198,7 @@ jobs:
         fetch-depth: 0 
     - name: Generate the sitemap
       id: sitemap
-      uses: cicirello/generate-sitemap@v1.6.0
+      uses: cicirello/generate-sitemap@v1.6.1
       with:
         base-url-path: https://THE.URL.TO.YOUR.PAGE/
     - name: Create Pull Request

--- a/generatesitemap.py
+++ b/generatesitemap.py
@@ -179,7 +179,7 @@ def urlstring(f, baseUrl) :
         u = f
     if len(u) >= 11 and u[-11:] == "/index.html" :
         u = u[:-10]
-    elif u == "index.html"
+    elif u == "index.html" :
         u = ""
     if len(u) >= 1 and u[0]=="/" and len(baseUrl) >= 1 and baseUrl[-1]=="/" :
         u = u[1:]

--- a/generatesitemap.py
+++ b/generatesitemap.py
@@ -61,8 +61,10 @@ def sortname(f) :
     Keyword arguments:
     f - Filename with path
     """
-    if len(f) >= 10 and f[-10:] == "index.html" :
+    if len(f) >= 11 and f[-11:] == "/index.html" :
         return f[:-10]
+    elif f == "index.html" :
+        return ""
     else :
         return f
 
@@ -175,8 +177,10 @@ def urlstring(f, baseUrl) :
         u = f[1:]
     else :
         u = f
-    if len(u) >= 10 and u[-10:] == "index.html" :
+    if len(u) >= 11 and u[-11:] == "/index.html" :
         u = u[:-10]
+    elif u == "index.html"
+        u = ""
     if len(u) >= 1 and u[0]=="/" and len(baseUrl) >= 1 and baseUrl[-1]=="/" :
         u = u[1:]
     elif (len(u)==0 or u[0]!="/") and (len(baseUrl)==0 or baseUrl[-1]!="/") :

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -45,7 +45,10 @@ class TestGenerateSitemap(unittest.TestCase) :
                     "/dir/index.html",
                     "/dir/dir/d.html",
                     "/dir/goodbye.html",
-                    "/dir/dir/c.html" ]
+                    "/dir/dir/c.html",
+                    "/aindex.html",
+                    "/dir/aindex.html"
+                  ]
         expected = [ "/dir/dir/z.pdf", 
                     "/dir/yoohoo.html",
                     "/x.pdf",
@@ -60,7 +63,10 @@ class TestGenerateSitemap(unittest.TestCase) :
                     "/dir/",
                     "/dir/dir/d.html",
                     "/dir/goodbye.html",
-                    "/dir/dir/c.html" ]
+                    "/dir/dir/c.html",
+                    "/aindex.html",
+                    "/dir/aindex.html"
+                  ]
         for i, f in enumerate(files) :
             self.assertEqual(gs.sortname(f), expected[i])
 
@@ -189,18 +195,24 @@ class TestGenerateSitemap(unittest.TestCase) :
                       "./subdir/index.html",
                       "./subdir/subdir/a.html",
                       "./subdir/subdir/index.html",
+                      "./aindex.html",
+                      "./subdir/aindex.html",
                       "/a.html",
                       "/index.html",
                       "/subdir/a.html",
                       "/subdir/index.html",
                       "/subdir/subdir/a.html",
                       "/subdir/subdir/index.html",
+                      "/aindex.html",
+                      "/subdir/aindex.html",
                       "a.html",
                       "index.html",
                       "subdir/a.html",
                       "subdir/index.html",
                       "subdir/subdir/a.html",
-                      "subdir/subdir/index.html"
+                      "subdir/subdir/index.html",
+                      "aindex.html",
+                      "subdir/aindex.html"
                       ]
         base1 = "https://TESTING.FAKE.WEB.ADDRESS.TESTING/"
         base2 = "https://TESTING.FAKE.WEB.ADDRESS.TESTING"
@@ -209,7 +221,9 @@ class TestGenerateSitemap(unittest.TestCase) :
                       "https://TESTING.FAKE.WEB.ADDRESS.TESTING/subdir/a.html",
                       "https://TESTING.FAKE.WEB.ADDRESS.TESTING/subdir/",
                       "https://TESTING.FAKE.WEB.ADDRESS.TESTING/subdir/subdir/a.html",
-                      "https://TESTING.FAKE.WEB.ADDRESS.TESTING/subdir/subdir/"
+                      "https://TESTING.FAKE.WEB.ADDRESS.TESTING/subdir/subdir/",
+                      "https://TESTING.FAKE.WEB.ADDRESS.TESTING/aindex.html",
+                      "https://TESTING.FAKE.WEB.ADDRESS.TESTING/subdir/aindex.html"
                      ]
         for i, f in enumerate(filenames) :
             self.assertEqual(expected[i%len(expected)], gs.urlstring(f, base1))


### PR DESCRIPTION
Fixed bug in generating URL for files with names ending in "index.html" but not exactly equal to "index.html", such as "aindex.html". Previous version would incorrectly truncate this to just "a", dropping the "index.html". This version now correctly identifies "index.html" files.