### PR TITLE
Fix for missing lastmod dates for files created during workflow but not yet committed

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,6 +28,9 @@ jobs:
     - name: Verify that the Docker image for the action builds
       run: docker build . --file Dockerfile
 
+    - name: Create new uncommitted html file for testing
+      run: touch tests/uncommitted.html
+
     - name: Integration test 1
       id: integration
       uses: ./

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [1.7.2] - 2021-05-13
 
+### Changed
+* Switched tag used to pull base Docker image from latest to the
+  specific release that is the current latest, to enable testing
+  against base image updates prior to releases. This is a purely
+  non-functional change.
+
 ### Fixed
 * Bug involving missing lastmod dates for website files created by
   the workflow, but not yet committed. These are now set using the 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased] - 2021-05-06
+## [Unreleased] - 2021-05-13
 
 ### Added
 
@@ -17,6 +17,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 ### CI/CD
+
+
+## [1.7.2] - 2021-05-13
+
+### Fixed
+* Bug involving missing lastmod dates for website files created by
+  the workflow, but not yet committed. These are now set using the 
+  current date and time.
 
 
 ## [1.7.1] - 2021-05-06

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
-# Copyright (c) 2020 Vincent A. Cicirello
+# Copyright (c) 2021 Vincent A. Cicirello
 # https://www.cicirello.org/
 # Licensed under the MIT License
-FROM cicirello/pyaction:latest
+FROM cicirello/pyaction:3.13.5
 COPY generatesitemap.py /generatesitemap.py
 ENTRYPOINT ["/generatesitemap.py"]

--- a/README.md
+++ b/README.md
@@ -334,6 +334,40 @@ jobs:
           [create-pull-request](https://github.com/peter-evans/create-pull-request) GitHub action.
 ```
 
+## Real Examples From Projects Using the Action
+
+### Personal Website
+
+This first real example is from the [personal website](https://www.cicirello.org/) 
+of the developer. One of the workflows, 
+[sitemap-generation.yml](https://github.com/cicirello/cicirello.github.io/blob/staging/.github/workflows/sitemap-generation.yml), 
+is strictly for generating the sitemap. It runs on pushes of either `*.html` or `*.pdf` 
+files to the staging branch of this repository. After generating the sitemap, it uses 
+[peter-evans/create-pull-request](https://github.com/peter-evans/create-pull-request)
+to generate a pull request. You can also replace that step with a commit and push instead.
+You can find the resulting sitemap here: [sitemap.xml](https://www.cicirello.org/sitemap.xml).
+
+### Documentation Website for a Java Library
+
+This next example is for the documentation website of 
+the [Chips-n-Salsa](https://chips-n-salsa.cicirello.org/) library. The
+[docs.yml](https://github.com/cicirello/Chips-n-Salsa/blob/master/.github/workflows/docs.yml)
+workflow runs on push and pull-requests of either `*.java` files. It uses Maven
+to run javadoc (e.g., with `mvn javadoc:javadoc`). It then copies the generated javadoc
+documentation to the `docs` directory, from which the API website is served. This is followed
+by another GitHub Action, 
+[cicirello/javadoc-cleanup](https://github.com/cicirello/javadoc-cleanup),
+which makes a few edits to the javadoc generated website to improve mobile browsing. 
+
+Next, it commits any changes (without pushing yet) produced by javadoc and/or 
+javadoc-cleanup. After performing those commits, it now runs the generate-sitemap
+action to generate the sitemap. It does this after committing the site changes so that
+the lastmod dates will be accurate. Finally, it uses 
+[peter-evans/create-pull-request](https://github.com/peter-evans/create-pull-request)
+to generate a pull request. You can also replace that step with a commit and push instead.
+
+You can find the resulting sitemap here: [sitemap.xml](https://chips-n-salsa.cicirello.org/sitemap.xml).
+ 
 ## License
 
 The scripts and documentation for this GitHub action is released under

--- a/README.md
+++ b/README.md
@@ -10,7 +10,9 @@ The generate-sitemap GitHub action generates a sitemap for a website hosted on G
 Pages, and has the following features:
 * Support for both xml and txt sitemaps (you choose using one of the action's inputs). 
 * When generating an xml sitemap, it uses the last commit date of 
-  each file to generate the `<lastmod>` tag in the sitemap entry. 
+  each file to generate the `<lastmod>` tag in the sitemap entry. If the file
+  was created during that workflow run, but not yet committed, then it instead uses
+  the current date (however, we recommend if possible committing newly created files first).
 * Supports URLs for html and pdf files in the sitemap, and has inputs 
   to control the included file types (defaults include both html and pdf files in the sitemap).
 * Now also supports including URLs for a user specified list of 

--- a/README.md
+++ b/README.md
@@ -167,7 +167,7 @@ you can also use a specific version such as with:
 
 ```yml
     - name: Generate the sitemap
-      uses: cicirello/generate-sitemap@v1.7.1
+      uses: cicirello/generate-sitemap@v1.7.2
       with:
         base-url-path: https://THE.URL.TO.YOUR.PAGE/
 ```

--- a/generatesitemap.py
+++ b/generatesitemap.py
@@ -31,6 +31,7 @@ import re
 import os
 import os.path
 import subprocess
+from datetime import datetime
 
 def gatherfiles(extensionsToInclude) :
     """Walks the directory tree discovering
@@ -199,9 +200,12 @@ def lastmod(f) :
     Keyword arguments:
     f - filename
     """
-    return subprocess.run(['git', 'log', '-1', '--format=%cI', f],
+    mod = subprocess.run(['git', 'log', '-1', '--format=%cI', f],
                     stdout=subprocess.PIPE,
                     universal_newlines=True).stdout.strip()
+    if len(mod) == 0 :
+        mod = datetime.now().astimezone().replace(microsecond=0).isoformat()
+    return mod
 
 def urlstring(f, baseUrl) :
     """Forms a string with the full url from a filename and base url.

--- a/tests/integration.py
+++ b/tests/integration.py
@@ -90,6 +90,8 @@ class IntegrationTest(unittest.TestCase) :
                      "https://TESTING.FAKE.WEB.ADDRESS.TESTING/x.pdf", 
                      "https://TESTING.FAKE.WEB.ADDRESS.TESTING/subdir/subdir/z.pdf",
                      "https://TESTING.FAKE.WEB.ADDRESS.TESTING/include.docx",
-                     "https://TESTING.FAKE.WEB.ADDRESS.TESTING/include.pptx"}
+                     "https://TESTING.FAKE.WEB.ADDRESS.TESTING/include.pptx",
+                     "https://TESTING.FAKE.WEB.ADDRESS.TESTING/uncommitted.html"
+                     }
         self.assertEqual(expected, urlset)
 

--- a/tests/integration.py
+++ b/tests/integration.py
@@ -27,7 +27,7 @@
 import unittest
 
 def validateDate(s) :
-    if len(s) < 26 :
+    if len(s) < 25 :
         return False
     if not s[0:4].isdigit() or s[4]!="-" or not s[5:7].isdigit() :
         return False

--- a/tests/integration.py
+++ b/tests/integration.py
@@ -26,6 +26,21 @@
 
 import unittest
 
+def validateDate(s) :
+    if len(s) < 26 :
+        return False
+    if not s[0:4].isdigit() or s[4]!="-" or not s[5:7].isdigit() :
+        return False
+    if s[7]!="-" or not s[8:10].isdigit() or s[10]!="T" :
+        return False
+    if not s[11:13].isdigit() or s[13]!=":" or not s[14:16].isdigit() :
+        return False
+    if s[16]!=":" or not s[17:19].isdigit() or (s[19]!="-" and s[19]!="+"):
+        return False
+    if not s[20:22].isdigit() or s[22]!=":" or not s[23:25].isdigit() :
+        return False
+    return  True
+        
 class IntegrationTest(unittest.TestCase) :
 
     def testIntegration(self) :
@@ -35,16 +50,29 @@ class IntegrationTest(unittest.TestCase) :
                 i = line.find("<loc>")
                 if i >= 0 :
                     i += 5
-                    j = line.find("</loc>", 5)
+                    j = line.find("</loc>", i)
                     if j >= 0 :
                         urlset.add(line[i:j].strip())
+                    else :
+                        self.fail("No closing </loc>")
+                i = line.find("<lastmod>")
+                if i >= 0 :
+                    i += 9
+                    j = line.find("</lastmod>", i)
+                    if j >= 0 :
+                        self.assertTrue(validateDate(line[i:j].strip()))
+                    else :
+                        self.fail("No closing </lastmod>")
+                    
         expected = { "https://TESTING.FAKE.WEB.ADDRESS.TESTING/unblocked1.html",
                      "https://TESTING.FAKE.WEB.ADDRESS.TESTING/unblocked2.html",
                      "https://TESTING.FAKE.WEB.ADDRESS.TESTING/unblocked3.html",
                      "https://TESTING.FAKE.WEB.ADDRESS.TESTING/unblocked4.html",
                      "https://TESTING.FAKE.WEB.ADDRESS.TESTING/subdir/a.html",
                      "https://TESTING.FAKE.WEB.ADDRESS.TESTING/x.pdf", 
-                     "https://TESTING.FAKE.WEB.ADDRESS.TESTING/subdir/subdir/z.pdf" }
+                     "https://TESTING.FAKE.WEB.ADDRESS.TESTING/subdir/subdir/z.pdf",
+                     "https://TESTING.FAKE.WEB.ADDRESS.TESTING/uncommitted.html"
+                     }
         self.assertEqual(expected, urlset)
 
     def testIntegrationWithAdditionalTypes(self) :

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -304,7 +304,7 @@ class TestGenerateSitemap(unittest.TestCase) :
         dateStr = gs.lastmod("./unblocked1.html")
         self.assertTrue(validateDate(dateStr), msg=dateStr)
         dateStr = gs.lastmod("./subdir/a.html")
-        self.assertTrue(validateDate(dateStr, msg=dateStr))
+        self.assertTrue(validateDate(dateStr), msg=dateStr)
         os.chdir("..")
 
     def test_urlstring(self) :

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -301,8 +301,10 @@ class TestGenerateSitemap(unittest.TestCase) :
 
     def test_lastmod(self) :
         os.chdir("tests")
-        self.assertTrue(validateDate(gs.lastmod("./unblocked1.html")))
-        self.assertTrue(validateDate(gs.lastmod("./subdir/a.html")))
+        dateStr = gs.lastmod("./unblocked1.html")
+        self.assertTrue(validateDate(dateStr), msg=dateStr)
+        dateStr = gs.lastmod("./subdir/a.html")
+        self.assertTrue(validateDate(dateStr, msg=dateStr))
         os.chdir("..")
 
     def test_urlstring(self) :

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -28,6 +28,21 @@ import unittest
 import generatesitemap as gs
 import os
 
+def validateDate(s) :
+    if len(s) < 26 :
+        return False
+    if not s[0:4].isdigit() or s[4]!="-" or not s[5:7].isdigit() :
+        return False
+    if s[7]!="-" or not s[8:10].isdigit() or s[10]!="T" :
+        return False
+    if not s[11:13].isdigit() or s[13]!=":" or not s[14:16].isdigit() :
+        return False
+    if s[16]!=":" or not s[17:19].isdigit() or (s[19]!="-" and s[19]!="+"):
+        return False
+    if not s[20:22].isdigit() or s[22]!=":" or not s[23:25].isdigit() :
+        return False
+    return  True
+
 class TestGenerateSitemap(unittest.TestCase) :
 
     def test_createExtensionSet_htmlOnly(self):
@@ -285,18 +300,6 @@ class TestGenerateSitemap(unittest.TestCase) :
         self.assertEqual(asSet, expected)
 
     def test_lastmod(self) :
-        def validateDate(s) :
-            if not s[0:4].isdigit() or s[4]!="-" or not s[5:7].isdigit() :
-                return False
-            if s[7]!="-" or not s[8:10].isdigit() or s[10]!="T" :
-                return False
-            if not s[11:13].isdigit() or s[13]!=":" or not s[14:16].isdigit() :
-                return False
-            if s[16]!=":" or not s[17:19].isdigit() or s[19]!="-" :
-                return False
-            if not s[20:22].isdigit() or s[22]!=":" or not s[23:25].isdigit() :
-                return False
-            return  True
         os.chdir("tests")
         self.assertTrue(validateDate(gs.lastmod("./unblocked1.html")))
         self.assertTrue(validateDate(gs.lastmod("./subdir/a.html")))

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -29,7 +29,7 @@ import generatesitemap as gs
 import os
 
 def validateDate(s) :
-    if len(s) < 26 :
+    if len(s) < 25 :
         return False
     if not s[0:4].isdigit() or s[4]!="-" or not s[5:7].isdigit() :
         return False


### PR DESCRIPTION
## Summary
This is a patch to fix the case of a missing date/time when a file is created by the workflow, but not committed prior to sitemap generation.

## Closing Issues
Fixes #29 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvements to existing code, such as refactoring or optimizations (non-breaking)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] I have read the [**CONTRIBUTING**](https://github.com/cicirello/.github/blob/main/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
