### PR TITLE
Bump python version

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,7 +20,7 @@ jobs:
     - name: Setup Python
       uses: actions/setup-python@v3
       with:
-        python-version: '3.8'
+        python-version: '3.10'
 
     - name: Run Python unit tests
       run: python3 -u -m unittest tests/tests.py

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,11 +4,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased] - 2021-07-29
+## [Unreleased] - 2022-03-04
 
 ### Added
 
 ### Changed
+* Bumped Python to 3.10.
+* Bumped base Docker image to pyaction 4.2.0.
+* Now pulls base Docker image from the GitHub Container Registry rather
+  than Docker Hub under the assumption that pulling from GitHub from
+  GitHub Actions is likely faster than from Docker Hub.
 
 ### Deprecated
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
-# Copyright (c) 2021 Vincent A. Cicirello
+# Copyright (c) 2021-2022 Vincent A. Cicirello
 # https://www.cicirello.org/
 # Licensed under the MIT License
-FROM cicirello/pyaction:4
+FROM ghcr.io/cicirello/pyaction:4.2.0
 COPY generatesitemap.py /generatesitemap.py
 ENTRYPOINT ["/generatesitemap.py"]


### PR DESCRIPTION
## Summary
Changed the following:
* Bumped Python to 3.10.
* Bumped base Docker image to pyaction 4.2.0.
* Now pulls base Docker image from the GitHub Container Registry rather
  than Docker Hub under the assumption that pulling from GitHub from
  GitHub Actions is likely faster than from Docker Hub.
