### PR TITLE
Refactored logic for dropping index.html from URLs 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,23 +4,24 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased] - 2022-07-25
+## [Unreleased] - 2022-08-03
 
 ### Added
 
 ### Changed
-* Bumped base docker image cicirello/pyaction from 4.3.1 to 4.7.0.
+* Refactored index.html dropping logic to ease support for additional dropped index filenames.
 
 ### Deprecated
 
 ### Removed
 
 ### Fixed
-* Checks .shtml files for noindex directives, excluding those that do from the sitemap.
+* Checks .shtml files for noindex directives, excluding those that have it from the sitemap.
 
 ### CI/CD
 
 ### Dependencies
+* Bumped base docker image cicirello/pyaction from 4.3.1 to 4.7.0.
 
 
 ## [1.8.3] - 2022-04-22

--- a/generatesitemap.py
+++ b/generatesitemap.py
@@ -50,6 +50,8 @@ def gatherfiles(extensionsToInclude) :
                 allfiles.append(os.path.join(root, f))
     return allfiles
 
+INDEX_FILENAMES = { "index.html" }
+
 def sortname(f, dropExtension=False) :
     """Partial url to sort by, which strips out the filename
     if the filename is index.html.
@@ -58,9 +60,10 @@ def sortname(f, dropExtension=False) :
     f - Filename with path
     dropExtension - true to drop extensions of .html from the filename when sorting
     """
-    if len(f) >= 11 and f[-11:] == "/index.html" :
-        return f[:-10]
-    elif f == "index.html" :
+    slash = f.rfind("/")
+    if slash >= 0 and slash < len(f)-1 and f[slash+1:] in INDEX_FILENAMES :
+        return f[:slash+1]
+    elif f in INDEX_FILENAMES :
         return ""
     elif dropExtension and len(f) >= 5 and f[-5:] == ".html" :
         return f[:-5]


### PR DESCRIPTION
## Summary
Refactored index.html dropping logic to ease support for additional dropped index filenames. In particular, this should simplify fix necessary for #52. 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Improvements to existing code, such as refactoring or optimizations (non-breaking)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] I have read the [**CONTRIBUTING**](https://github.com/cicirello/.github/blob/main/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
