### PR TITLE
Replaced usage of GitHub Action's deprecated set-output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased] - 2022-10-19
+## [Unreleased] - 2022-10-20
 
 ### Added
 
@@ -15,8 +15,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 
 ### Fixed
-* Now handles alternate casing of boolean inputs specified in GitHub workflow YAML files,
-  where it previously expected lowercase only.
+* Replaced the usage of GitHub Action's deprecated `set-output` with the new `$GITHUB_OUTPUT` env file.
+* Handle alternate casing of boolean inputs in GitHub workflow YAML files (previously expected lowercase).
 * Refactored entrypoint for improved maintainability, and ease of planned new functionality.
 
 ### CI/CD

--- a/generatesitemap.py
+++ b/generatesitemap.py
@@ -289,6 +289,17 @@ def writeXmlSitemap(files, baseUrl, dropExtension=False) :
             sitemap.write("\n")
         sitemap.write('</urlset>\n')
 
+def set_outputs(names_values) :
+    """Sets the GitHub Action outputs.
+
+    Keyword arguments:
+    names_values - Dictionary of output names with values
+    """
+    if "GITHUB_OUTPUT" in os.environ :
+        with open(os.environ["GITHUB_OUTPUT"], "a") as f :
+            for name, value in names_values.items() :
+                print("{0}={1}".format(name, value), file=f)
+
 def main(
         websiteRoot,
         baseUrl,
@@ -332,10 +343,11 @@ def main(
         writeTextSitemap(files, baseUrl, dropExtension)
         pathToSitemap += "sitemap.txt"
 
-    print("::set-output name=sitemap-path::" + pathToSitemap)
-    print("::set-output name=url-count::" + str(len(files)))
-    print("::set-output name=excluded-count::" + str(len(allFiles)-len(files)))
-
+    set_outputs({
+        "sitemap-path" : pathToSitemap,
+        "url-count" : len(files),
+        "excluded-count" : len(allFiles)-len(files)
+    })
 
 if __name__ == "__main__" :
     main(


### PR DESCRIPTION
## Summary
Replaced the usage of GitHub Action's deprecated `set-output` with the new `$GITHUB_OUTPUT` env file.

## Closing Issues
Fixes #70 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvements to existing code, such as refactoring or optimizations (non-breaking)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] I have read the [**CONTRIBUTING**](https://github.com/cicirello/.github/blob/main/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
