### PR TITLE
Added backwards compatibility for self-hosted runners without the GITHUB_OUTPUT env file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased] - 2022-10-21
+## [Unreleased] - 2022-10-24
 
 ### Added
 
@@ -17,6 +17,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 ### CI/CD
+
+### Dependencies
+
+
+## [1.8.6] - 2022-10-24
+
+### Fixed
+* Some users may be using the action on a self-hosted runner not yet updated to a version supporting the
+  new GitHub Actions `GITHUB_OUTPUT` environment file. This patch adds backwards compatibility for those
+  users (e.g., it falls back to using the deprecated `set-output` if `GITHUB_OUTPUT` doesn't exist).
 
 ### Dependencies
 * Bump cicirello/pyaction from 4.11.0 to 4.11.1

--- a/generatesitemap.py
+++ b/generatesitemap.py
@@ -299,6 +299,9 @@ def set_outputs(names_values) :
         with open(os.environ["GITHUB_OUTPUT"], "a") as f :
             for name, value in names_values.items() :
                 print("{0}={1}".format(name, value), file=f)
+    else : # Fall-back to deprecated set-output for non-updated runners
+        for name, value in names_values.items() :
+            print("::set-output name={0}::{1}".format(name, value))
 
 def main(
         websiteRoot,


### PR DESCRIPTION
## Summary
Some users may be using the action on a self-hosted runner not yet updated to a version supporting the new GitHub Actions `GITHUB_OUTPUT` environment file. This patch adds backwards compatibility for those users (e.g., it falls back to using the deprecated `set-output` if `GITHUB_OUTPUT` doesn't exist).

## Closing Issues
Closes #74 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvements to existing code, such as refactoring or optimizations (non-breaking)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] I have read the [**CONTRIBUTING**](https://github.com/cicirello/.github/blob/main/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
