### PR TITLE
Bump Python to 3.11 in CI/CD workflows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,7 +23,7 @@ jobs:
     - name: Setup Python
       uses: actions/setup-python@v4
       with:
-        python-version: '3.10'
+        python-version: '3.11'
 
     - name: Run Python unit tests
       run: python3 -u -m unittest tests/tests.py

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 ### CI/CD
+* Bump Python to 3.11 in CI/CD workflows.
 
 ### Dependencies
 * Bump cicirello/pyaction from 4.11.1 to 4.12.0, which includes upgrading Python in the Docker container to 3.11.0.


### PR DESCRIPTION
## Summary
Bump Python to 3.11 in CI/CD workflows
