### PR TITLE
Option to include dates only in the lastmod fields of XML sitemaps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 ### CI/CD
+
+### Dependencies
+
+
+## [1.9.0] - 2022-10-25
+
+### Added
+* Option to include dates only in the lastmod fields of XML sitemaps. Default includes full date-time.
+
+### CI/CD
 * Bump Python to 3.11 in CI/CD workflows.
 
 ### Dependencies

--- a/README.md
+++ b/README.md
@@ -162,7 +162,13 @@ for pages where the filename has the `.html` extension. If you prefer to exclude
 `.html` extension from the URLs in your sitemap, then 
 pass `drop-html-extension: true` to the action in your workflow. 
 Note that you should also ensure that any canonical links that you list within
-the html files corresponds to your choice here.  
+the html files corresponds to your choice here.
+
+### `date-only`
+
+The `date-only` input controls whether XML sitemaps include the full date and time in lastmod,
+or only the date. The default is `date-only: false`, which includes the full date and time
+in the lastmod fields. If you only want the date in the lastmod, then use `date-only: true`.
 
 ## Outputs
 
@@ -203,7 +209,7 @@ you can also use a specific version such as with:
 
 ```yml
     - name: Generate the sitemap
-      uses: cicirello/generate-sitemap@v1.8.5
+      uses: cicirello/generate-sitemap@v1.9.0
       with:
         base-url-path: https://THE.URL.TO.YOUR.PAGE/
 ```

--- a/action.yml
+++ b/action.yml
@@ -57,6 +57,10 @@ inputs:
     description: 'Enables dropping .html from urls in sitemap.'
     required: false
     default: false
+  date-only:
+    description: 'Pass true to include only the date without the time in XML sitemaps; and false to include full date and time.'
+    required: false
+    default: false
 outputs:
   sitemap-path: 
     description: 'The path to the generated sitemap file.'
@@ -75,3 +79,4 @@ runs:
     - ${{ inputs.sitemap-format }}
     - ${{ inputs.additional-extensions }}
     - ${{ inputs.drop-html-extension }}
+    - ${{ inputs.date-only }}

--- a/generatesitemap.py
+++ b/generatesitemap.py
@@ -247,8 +247,16 @@ xmlSitemapEntryTemplate = """<url>
 <loc>{0}</loc>
 <lastmod>{1}</lastmod>
 </url>"""	
-	
-def xmlSitemapEntry(f, baseUrl, dateString, dropExtension=False) :
+
+def removeTime(dateString) :
+    """Removes the time from a date-time.
+
+    Keyword arguments:
+    dateString - The date-time.
+    """
+    return dateString[:10]
+
+def xmlSitemapEntry(f, baseUrl, dateString, dropExtension=False, dateOnly=False) :
     """Forms a string with an entry formatted for an xml sitemap
     including lastmod date.
 
@@ -258,7 +266,10 @@ def xmlSitemapEntry(f, baseUrl, dateString, dropExtension=False) :
     dateString - lastmod date correctly formatted
     dropExtension - true to drop extensions of .html from the filename in urls
     """
-    return xmlSitemapEntryTemplate.format(urlstring(f, baseUrl, dropExtension), dateString)
+    return xmlSitemapEntryTemplate.format(
+        urlstring(f, baseUrl, dropExtension),
+        removeTime(dateString) if dateOnly else dateString
+    )
 
 def writeTextSitemap(files, baseUrl, dropExtension=False) :
     """Writes a plain text sitemap to the file sitemap.txt.
@@ -273,7 +284,7 @@ def writeTextSitemap(files, baseUrl, dropExtension=False) :
             sitemap.write(urlstring(f, baseUrl, dropExtension))
             sitemap.write("\n")
             
-def writeXmlSitemap(files, baseUrl, dropExtension=False) :
+def writeXmlSitemap(files, baseUrl, dropExtension=False, dateOnly=False) :
     """Writes an xml sitemap to the file sitemap.xml.
 
     Keyword Arguments:
@@ -285,7 +296,7 @@ def writeXmlSitemap(files, baseUrl, dropExtension=False) :
         sitemap.write('<?xml version="1.0" encoding="UTF-8"?>\n')
         sitemap.write('<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">\n')
         for f in files :
-            sitemap.write(xmlSitemapEntry(f, baseUrl, lastmod(f), dropExtension))
+            sitemap.write(xmlSitemapEntry(f, baseUrl, lastmod(f), dropExtension, dateOnly))
             sitemap.write("\n")
         sitemap.write('</urlset>\n')
 
@@ -310,7 +321,8 @@ def main(
         includePDF,
         sitemapFormat,
         additionalExt,
-        dropExtension
+        dropExtension,
+        dateOnly
     ) :
     """The main function of the generate-sitemap GitHub Action.
 
@@ -340,7 +352,7 @@ def main(
     if pathToSitemap[-1] != "/" :
         pathToSitemap += "/"
     if sitemapFormat == "xml" :
-        writeXmlSitemap(files, baseUrl, dropExtension)
+        writeXmlSitemap(files, baseUrl, dropExtension, dateOnly)
         pathToSitemap += "sitemap.xml"
     else :
         writeTextSitemap(files, baseUrl, dropExtension)
@@ -360,7 +372,8 @@ if __name__ == "__main__" :
         includePDF = sys.argv[4].lower() == "true",
         sitemapFormat = sys.argv[5],
         additionalExt = set(sys.argv[6].lower().replace(",", " ").replace(".", " ").split()),
-        dropExtension = sys.argv[7].lower() == "true"
+        dropExtension = sys.argv[7].lower() == "true",
+        dateOnly = sys.argv[8].lower() == "true"
     )
 
     

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -570,6 +570,11 @@ class TestGenerateSitemap(unittest.TestCase) :
             self.assertEqual(expected[i%len(expected)], gs.urlstring(f, base1, True))
             self.assertEqual(expected[i%len(expected)], gs.urlstring(f, base2, True))
 
+    def test_removeTime(self) :
+        date = "2020-09-11T13:35:00-04:00"
+        expected = "2020-09-11"
+        self.assertEqual(expected, gs.removeTime(date))
+        
     def test_xmlSitemapEntry(self) :
         base = "https://TESTING.FAKE.WEB.ADDRESS.TESTING/"
         f = "./a.html"
@@ -579,6 +584,17 @@ class TestGenerateSitemap(unittest.TestCase) :
         self.assertEqual(actual, expected)
         actual = gs.xmlSitemapEntry(f, base, date, True)
         expected = "<url>\n<loc>https://TESTING.FAKE.WEB.ADDRESS.TESTING/a</loc>\n<lastmod>2020-09-11T13:35:00-04:00</lastmod>\n</url>"
+        self.assertEqual(actual, expected)
+
+    def test_xmlSitemapEntryDateOnly(self) :
+        base = "https://TESTING.FAKE.WEB.ADDRESS.TESTING/"
+        f = "./a.html"
+        date = "2020-09-11T13:35:00-04:00"
+        actual = gs.xmlSitemapEntry(f, base, date, False, True)
+        expected = "<url>\n<loc>https://TESTING.FAKE.WEB.ADDRESS.TESTING/a.html</loc>\n<lastmod>2020-09-11</lastmod>\n</url>"
+        self.assertEqual(actual, expected)
+        actual = gs.xmlSitemapEntry(f, base, date, True, True)
+        expected = "<url>\n<loc>https://TESTING.FAKE.WEB.ADDRESS.TESTING/a</loc>\n<lastmod>2020-09-11</lastmod>\n</url>"
         self.assertEqual(actual, expected)
 
     def test_robotsTxtParser(self) :


### PR DESCRIPTION
## Summary
Option to include dates only in the lastmod fields of XML sitemaps. Default includes full date-time. Feature controlled by a new input `date-only`.

## Closing Issues
Closes #58 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Improvements to existing code, such as refactoring or optimizations (non-breaking)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] I have read the [**CONTRIBUTING**](https://github.com/cicirello/.github/blob/main/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
