### PR TITLE
Fixed error in regex that detects noindex directives, and bumped Python to 3.12 in CI/CD workflow when running unit tests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,7 +23,7 @@ jobs:
     - name: Setup Python
       uses: actions/setup-python@v4
       with:
-        python-version: '3.11'
+        python-version: '3.12'
 
     - name: Run Python unit tests
       run: python3 -u -m unittest tests/tests.py

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 
 ### Fixed
+* Fix minor bug in regex used to detect if a page has a meta robots noindex directive in head.
 
 ### CI/CD
 * Bump Python to 3.12 in CI/CD workflows when running unit tests.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased] - 2023-09-22
+## [Unreleased] - 2023-10-05
 
 ### Added
 
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 ### CI/CD
+* Bump Python to 3.12 in CI/CD workflows when running unit tests.
 
 ### Dependencies
 * Bump cicirello/pyaction from 4.14.1 to 4.24.0

--- a/generatesitemap.py
+++ b/generatesitemap.py
@@ -103,7 +103,7 @@ def hasMetaRobotsNoindex(f) :
                 m = re.search("<body>", contents, flags=re.I)
             all_meta_tags = RE_META_TAG.findall(contents, endpos=m.start()) if m else RE_META_TAG.findall(contents)
             for tag in all_meta_tags :
-                if re.search("name\s*=\s*\"\s*robots", tag, flags=re.I) and re.search("content\s*=\s*\".*noindex", tag, flags=re.I) :
+                if re.search("name\\s*=\\s*\"\\s*robots", tag, flags=re.I) and re.search("content\\s*=\\s*\".*noindex", tag, flags=re.I) :
                     return True
             return False
     except OSError:


### PR DESCRIPTION
## Summary
Fixed a bug in the regular expression used to detect if a page has a meta robots noindex directive in the head. Bug related to `\s*` for detecting a sequence of 0 or more spaces *possibly* not being correctly passed to Python's regex processor. Python 3.12 gives a warning of an invalid escape sequence. Need to escape the slash so it is passed to regex processor, and not treated as an escape in the string. Curiously, earlier versions of Python don't warn about this. I haven't been able to create an example that demonstrates the bug, which suggests that a `\s` is being passed through to the regex processor as desired. But should fix this anyway, as future versions of Python may treat the invalid escape sequence differently.

Bump Python to 3.12 in CI/CD workflow when running unit tests, in preparation for bumping Python to 3.12 within the Docker container for the action.

## Closing Issues
Closes #107 
Closes #110 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/cicirello/.github/blob/main/CONTRIBUTING.md) document.
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Improvements to existing code, such as refactoring or optimizations (non-breaking)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
