### PR TITLE
Escape characters that must be escaped in XML

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased] - 2024-05-20
+## [Unreleased] - 2024-06-08
 
 ### Added
 
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 
 ### Fixed
+* Escape characters that must be escaped in XML.
 
 ### CI/CD
 

--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ sure to include the following as a step in your workflow:
 ```yml
     steps:
     - name: Checkout the repo
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         fetch-depth: 0 
 ```
@@ -242,7 +242,7 @@ you can also use a specific version such as with:
 
 ```yml
     - name: Generate the sitemap
-      uses: cicirello/generate-sitemap@v1.10.0
+      uses: cicirello/generate-sitemap@v1.10.1
       with:
         base-url-path: https://THE.URL.TO.YOUR.PAGE/
 ```
@@ -268,7 +268,7 @@ jobs:
 
     steps:
     - name: Checkout the repo
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         fetch-depth: 0 
 
@@ -306,7 +306,7 @@ jobs:
 
     steps:
     - name: Checkout the repo
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         fetch-depth: 0 
 
@@ -348,7 +348,7 @@ jobs:
 
     steps:
     - name: Checkout the repo
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         fetch-depth: 0 
 
@@ -389,7 +389,7 @@ jobs:
 
     steps:
     - name: Checkout the repo
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         fetch-depth: 0 
 

--- a/action.yml
+++ b/action.yml
@@ -1,6 +1,6 @@
 # generate-sitemap: Github action for automating sitemap generation
 # 
-# Copyright (c) 2020-2023 Vincent A Cicirello
+# Copyright (c) 2020-2024 Vincent A Cicirello
 # https://www.cicirello.org/
 #
 # MIT License

--- a/generatesitemap.py
+++ b/generatesitemap.py
@@ -2,7 +2,7 @@
 #
 # generate-sitemap: Github action for automating sitemap generation
 # 
-# Copyright (c) 2020-2023 Vincent A Cicirello
+# Copyright (c) 2020-2024 Vincent A Cicirello
 # https://www.cicirello.org/
 #
 # MIT License
@@ -262,6 +262,25 @@ def removeTime(dateString) :
     """
     return dateString[:10]
 
+def xmlEscapeCharacters(f):
+    """Escapes any characters that XML requires escaped, such as
+    ampersands, etc.
+
+    Keyword arguments:
+    f - the filename
+    """
+    return f.replace(
+        "&", "&amp;"
+    ).replace(
+        "<", "&lt;"
+    ).replace(
+        ">", "&gt;"
+    ).replace(
+        "'", "&apos;"
+    ).replace(
+        '"', "&quot;"
+    )
+
 def xmlSitemapEntry(f, baseUrl, dateString, dropExtension=False, dateOnly=False) :
     """Forms a string with an entry formatted for an xml sitemap
     including lastmod date.
@@ -273,7 +292,7 @@ def xmlSitemapEntry(f, baseUrl, dateString, dropExtension=False, dateOnly=False)
     dropExtension - true to drop extensions of .html from the filename in urls
     """
     return xmlSitemapEntryTemplate.format(
-        urlstring(f, baseUrl, dropExtension),
+        urlstring(xmlEscapeCharacters(f), baseUrl, dropExtension),
         removeTime(dateString) if dateOnly else dateString
     )
 

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -1,6 +1,6 @@
 # generate-sitemap: Github action for automating sitemap generation
 # 
-# Copyright (c) 2020-2023 Vincent A Cicirello
+# Copyright (c) 2020-2024 Vincent A Cicirello
 # https://www.cicirello.org/
 #
 # MIT License
@@ -590,6 +590,26 @@ class TestGenerateSitemap(unittest.TestCase) :
         date = "2020-09-11T13:35:00-04:00"
         expected = "2020-09-11"
         self.assertEqual(expected, gs.removeTime(date))
+
+    def test_xmlEscapeCharacters(self):
+        test_strings = [
+            "abs&def",
+            "abs<def",
+            "abs>def",
+            "abs'def",
+            'abs"def',
+            """&<>"'"'><&"""
+        ]
+        expected = [
+            "abs&amp;def",
+            "abs&lt;def",
+            "abs&gt;def",
+            "abs&apos;def",
+            "abs&quot;def",
+            "&amp;&lt;&gt;&quot;&apos;&quot;&apos;&gt;&lt;&amp;"
+        ]
+        for t, e in zip(test_strings, expected):
+            self.assertEqual(e, gs.xmlEscapeCharacters(t))
         
     def test_xmlSitemapEntry(self) :
         base = "https://TESTING.FAKE.WEB.ADDRESS.TESTING/"
@@ -612,6 +632,36 @@ class TestGenerateSitemap(unittest.TestCase) :
         actual = gs.xmlSitemapEntry(f, base, date, True, True)
         expected = "<url>\n<loc>https://TESTING.FAKE.WEB.ADDRESS.TESTING/a</loc>\n<lastmod>2020-09-11</lastmod>\n</url>"
         self.assertEqual(actual, expected)
+
+    def test_xmlSitemapEntry_withEscapes(self):
+        base = "https://TESTING.FAKE.WEB.ADDRESS.TESTING/"
+        f_template = "./a{0}.html"
+        date = "2020-09-11T13:35:00-04:00"
+        test_strings = [
+            "abs&def",
+            "abs<def",
+            "abs>def",
+            "abs'def",
+            'abs"def',
+            """&<>"'"'><&"""
+        ]
+        expected = [
+            "abs&amp;def",
+            "abs&lt;def",
+            "abs&gt;def",
+            "abs&apos;def",
+            "abs&quot;def",
+            "&amp;&lt;&gt;&quot;&apos;&quot;&apos;&gt;&lt;&amp;"
+        ]
+        for t, e in zip(test_strings, expected):
+            f = f_template.format(t)
+            self.assertEqual(e, gs.xmlEscapeCharacters(t))
+            actual = gs.xmlSitemapEntry(f, base, date)
+            expected = "<url>\n<loc>https://TESTING.FAKE.WEB.ADDRESS.TESTING/a{0}.html</loc>\n<lastmod>2020-09-11T13:35:00-04:00</lastmod>\n</url>".format(e)
+            self.assertEqual(actual, expected)
+            actual = gs.xmlSitemapEntry(f, base, date, True)
+            expected = "<url>\n<loc>https://TESTING.FAKE.WEB.ADDRESS.TESTING/a{0}</loc>\n<lastmod>2020-09-11T13:35:00-04:00</lastmod>\n</url>".format(e)
+            self.assertEqual(actual, expected)
 
     def test_robotsTxtParser(self) :
         expected = [ [],


### PR DESCRIPTION
## Summary
Escape characters that must be escaped in XML, including `&`, `<`, `>`, `"`,  and `'`.

## Closing Issues
Closes #123 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/cicirello/.github/blob/main/CONTRIBUTING.md) document.
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvements to existing code, such as refactoring or optimizations (non-breaking)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
