### PR TITLE
Bumps cicirello/pyaction to 3.13.5-gh-2.75.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # Copyright (c) 2021-2025 Vincent A. Cicirello
 # https://www.cicirello.org/
 # Licensed under the MIT License
-FROM ghcr.io/cicirello/pyaction:4.33.0
+FROM ghcr.io/cicirello/pyaction:3.13.5-gh-2.75.1
 COPY generatesitemap.py /generatesitemap.py
 ENTRYPOINT ["/generatesitemap.py"]


### PR DESCRIPTION
## Summary
The base Docker image cicirello/pyaction has a new tagging scheme that specifies Python version and GitHub CLI version. Switch to the latest tag: 3.13.5-gh-2.75.1

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/cicirello/.github/blob/main/CONTRIBUTING.md) document.
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Improvements to existing code, such as refactoring or optimizations (non-breaking)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
